### PR TITLE
Make outli--at-heading work anywhere in outline regexp rather than only bol.

### DIFF
--- a/outli.el
+++ b/outli.el
@@ -173,7 +173,7 @@ command."
   (if (outline-on-heading-p) cmd))
 
 (defun outli--at-heading (cmd)
-  (and (bolp) (looking-at outline-regexp) cmd))
+  (and (outline-on-heading-p) (thing-at-point-looking-at outline-regexp) cmd))
 
 ;;;; Outline Commands
 (defun outli-toggle-narrow-to-subtree ()


### PR DESCRIPTION
Uses 'thing-at-point-looking-at' instead of 'looking-at'. Also adds a check to make sure point is on an outline heading.